### PR TITLE
Navigating back form FilesScreen should skip SubFolderScreen when no parent

### DIFF
--- a/app/SubFolderScreen.tsx
+++ b/app/SubFolderScreen.tsx
@@ -105,6 +105,7 @@ interface SubCategory {
         if(uniqueSubcategories.length === 0) {
           if (justVisitedFilesScreen.current) {
             justVisitedFilesScreen.current = false;
+            router.back();
           } else {
             console.log("FIlESCREEN", category);
             if (hierarchy !== null) {


### PR DESCRIPTION
Fixes #37